### PR TITLE
Fix Lizzie's import path for arianna_utils

### DIFF
--- a/lizzie/lizzie.py
+++ b/lizzie/lizzie.py
@@ -11,7 +11,8 @@ import openai
 from fastapi import FastAPI
 from pydantic import BaseModel
 
-
+"""Ensure project root is on sys.path for arianna_utils imports"""
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
 LOG_DIR = Path("logs/agents")
 LOG_DIR.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
## Summary
- ensure project root is added to `sys.path` in `lizzie.py`

## Testing
- `python - <<'PY'
from lizzie.lizzie import LizzieAgent
from importlib import import_module
mod = import_module('arianna_utils.agent_logic')
print('imported', hasattr(mod, 'get_agent_logic'))
PY`
- `./run-tests.sh` *(fails: flake8: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b1ff37673883299ad460b349e190b4